### PR TITLE
Optional token burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Watch out: Since the account will be deploying the Smart Contracts, it will also
 
 ### Locally
 
-Please run `testrpc` in one console and `truffle test` to see the tests.
+Please run `ganache-cli -e 1000 -a 100` in one console and `truffle test` to see the tests.
 
 ### Testnet & Mainnet
 

--- a/contracts/Crowdsale/DSLACrowdsale.sol
+++ b/contracts/Crowdsale/DSLACrowdsale.sol
@@ -198,19 +198,26 @@ contract DSLACrowdsale is VestedCrowdsale, Whitelist, Pausable, PullPayment {
 
     /**
       * @dev Function to finalize the crowdsale
+      * @param _burn bool burn unsold tokens when true
       * @return True bool
       */
-    function finalizeCrowdsale() public onlyOwner returns(bool) {
+    function finalizeCrowdsale(bool _burn) public onlyOwner returns(bool) {
         require(currentIcoRound == 4 && !isRefunding);
 
         if (raisedFunds() < icoRounds[3].softCap) {
             isRefunding = true;
             refundDeadline = block.timestamp + 4 weeks;
-        } else {
-            require(!isFinalized);
-            _withdrawFunds(wallet());
+
+            return true;
+        }
+
+        require(!isFinalized);
+
+        _withdrawFunds(wallet());
+        isFinalized = true;
+
+        if (_burn) {
             _burnUnsoldTokens();
-            isFinalized = true;
         }
 
         return  true;

--- a/contracts/Crowdsale/DSLACrowdsale.sol
+++ b/contracts/Crowdsale/DSLACrowdsale.sol
@@ -218,6 +218,8 @@ contract DSLACrowdsale is VestedCrowdsale, Whitelist, Pausable, PullPayment {
 
         if (_burn) {
             _burnUnsoldTokens();
+        } else {
+            _withdrawUnsoldTokens();
         }
 
         return  true;
@@ -395,5 +397,15 @@ contract DSLACrowdsale is VestedCrowdsale, Whitelist, Pausable, PullPayment {
         uint256 tokensToBurn = TOKENSFORSALE.sub(vestedTokens).sub(distributedTokens);
 
         _token.burn(tokensToBurn);
+    }
+
+    /**
+      * @dev Transfer the unsold tokens to the funds collecting address
+      */
+    function _withdrawUnsoldTokens()
+    internal {
+        uint256 tokensToWithdraw = TOKENSFORSALE.sub(vestedTokens).sub(distributedTokens);
+
+        _token.transfer(_wallet, tokensToWithdraw);
     }
 }

--- a/test/refund.test.js
+++ b/test/refund.test.js
@@ -55,7 +55,7 @@ contract('Refund', function ([owner, project, anotherAccount, user1, user2, wall
 
             await crowdsale.closeCrowdsale({from : owner});
 
-            await crowdsale.finalizeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
 
             // claim a refund
             await assertRevert(crowdsale.claimRefund({from : user1}));
@@ -79,7 +79,7 @@ contract('Refund', function ([owner, project, anotherAccount, user1, user2, wall
 
             await crowdsale.closeCrowdsale({from : owner});
 
-            await crowdsale.finalizeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
 
             // claim a refund
             await crowdsale.claimRefund({from : user1, gasPrice : 0});
@@ -109,7 +109,7 @@ contract('Refund', function ([owner, project, anotherAccount, user1, user2, wall
             assert.equal(await crowdsale.raisedFunds.call().valueOf(), paymentAmount.valueOf());
 
             await crowdsale.closeCrowdsale({from : owner});
-            await crowdsale.finalizeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
 
             // claim a refund
             await crowdsale.claimRefund({from : user1, gasPrice : 0});
@@ -131,7 +131,7 @@ contract('Refund', function ([owner, project, anotherAccount, user1, user2, wall
 
             await crowdsale.closeCrowdsale({from : owner});
 
-            await crowdsale.finalizeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
 
             // increase time to after refund period
             await increaseTimeTo(latestTime() + duration.weeks(4));
@@ -153,7 +153,7 @@ contract('Refund', function ([owner, project, anotherAccount, user1, user2, wall
             await crowdsale.sendTransaction({ from: user1 , value: paymentAmount });
 
             await crowdsale.closeCrowdsale({from : owner});
-            await crowdsale.finalizeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
 
             // increase time to after refund period
             await increaseTimeTo(latestTime() + duration.weeks(5));

--- a/test/sale.test.js
+++ b/test/sale.test.js
@@ -172,5 +172,122 @@ contract('ROUND 3', function ([owner, project, anotherAccount, user1, user2, wal
             // check raised funds from other currencies
             assert.equal(await crowdsale.weiRaisedFromOtherCurrencies.call().valueOf(), paymentAmount.valueOf());
         });
+        it('finalizes crowdsale and burns unsold tokens', async function () {
+            let addresses = web3.eth.accounts.slice (5, 99);
+            await crowdsale.addAddressToWhitelist(addresses, {from : owner});
+
+            // Round 1 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 1);
+
+            addresses.slice(0, 10).map(async address => {
+              await crowdsale.addPrivateSaleContributors(address , web3.toWei('110', 'ether'), {from : owner});
+            });
+
+            // Round 2 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 2);
+
+            addresses.slice(10, 24).map(async address => {
+              await crowdsale.sendTransaction({from : address, value: web3.toWei('350', 'ether')});
+            });
+
+            // Round 3 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 3);
+
+            addresses.slice(24, 75).map(async address => {
+              return await crowdsale.sendTransaction({from : address, value: web3.toWei('29', 'ether')});
+            });
+
+            let raisedFunds = new BigNumber(await crowdsale.raisedFunds.call()).toNumber();
+
+            // SoftCap reached
+            assert.isAbove(raisedFunds, new BigNumber(softCap).toNumber());
+            assert.isBelow(raisedFunds, new BigNumber(hardCap).toNumber());
+
+            // Finalize crowdsale and burn unsold tokens
+            let walletBalance = new BigNumber(await token.balanceOf(wallet, {from: owner}));
+            let distributedTokens = new BigNumber(await crowdsale.distributedTokens.call());
+            let vestedTokens = new BigNumber(await crowdsale.vestedTokens.call());
+            let soldTokens = distributedTokens.add(vestedTokens);
+            var crowdsaleBalance = new BigNumber(await token.balanceOf(crowdsale.address, {from: owner}));
+            var totalSupply = new BigNumber(await token.totalSupply({from: owner}));
+
+            assert.equal(crowdsaleBalance.toNumber(), tokensToSell.sub(distributedTokens).toNumber());
+            assert.equal(totalSupply.toNumber(), new BigNumber('10e27').toNumber());
+
+            await crowdsale.closeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(true, {from : owner});
+
+            // Walletbalance stays the same
+            assert.equal(walletBalance.toNumber(), new BigNumber(await token.balanceOf(wallet, {from: owner})).toNumber());
+
+            // CrowdsaleBalance only has vestedTokens, the rest is burned.
+            crowdsaleBalance = new BigNumber(await token.balanceOf(crowdsale.address, {from: owner}));
+            assert.equal(crowdsaleBalance.toNumber(), vestedTokens.toNumber());
+
+            totalSupply = totalSupply.sub(tokensToSell.sub(soldTokens));
+            assert.equal(totalSupply.toNumber(), new BigNumber(await token.totalSupply({from: owner})).toNumber());
+        });
+        it('finalizes crowdsale and does not burn unsold tokens', async function () {
+            let addresses = web3.eth.accounts.slice (5, 99);
+            await crowdsale.addAddressToWhitelist(addresses, {from : owner});
+
+            // Round 1 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 1);
+
+            addresses.slice(0, 10).map(async address => {
+              await crowdsale.addPrivateSaleContributors(address , web3.toWei('110', 'ether'), {from : owner});
+            });
+
+            // Round 2 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 2);
+
+            addresses.slice(10, 24).map(async address => {
+              await crowdsale.sendTransaction({from : address, value: web3.toWei('350', 'ether')});
+            });
+
+            // Round 3 contributions
+            await crowdsale.goToNextRound({from : owner});
+            assert.equal(await crowdsale.currentIcoRound.call(), 3);
+
+            addresses.slice(24, 75).map(async address => {
+              return await crowdsale.sendTransaction({from : address, value: web3.toWei('29', 'ether')});
+            });
+
+            let raisedFunds = new BigNumber(await crowdsale.raisedFunds.call()).toNumber();
+
+            // SoftCap reached
+            assert.isAbove(raisedFunds, new BigNumber(softCap).toNumber());
+            assert.isBelow(raisedFunds, new BigNumber(hardCap).toNumber());
+
+            // Finalize crowdsale without burning unsold tokens
+            let walletBalance = new BigNumber(await token.balanceOf(wallet, {from: owner}));
+            let distributedTokens = new BigNumber(await crowdsale.distributedTokens.call());
+            let vestedTokens = new BigNumber(await crowdsale.vestedTokens.call());
+            let soldTokens = distributedTokens.add(vestedTokens);
+            let unsoldTokens = tokensToSell.sub(soldTokens);
+            let crowdsaleBalance = new BigNumber(await token.balanceOf(crowdsale.address, {from: owner}));
+            let totalSupply = new BigNumber(await token.totalSupply({from: owner}));
+
+            assert.equal(crowdsaleBalance.toNumber(), tokensToSell.sub(distributedTokens).toNumber());
+            assert.equal(totalSupply.toNumber(), new BigNumber('10e27').toNumber());
+
+            await crowdsale.closeCrowdsale({from : owner});
+            await crowdsale.finalizeCrowdsale(false, {from : owner});
+
+            // Walletbalance increased with unsoldTokens
+            assert.equal(walletBalance.add(unsoldTokens).toNumber(), new BigNumber(await token.balanceOf(wallet, {from: owner})).toNumber());
+
+            // CrowdsaleBalance only has vestedTokens, the rest is send to wallet address.
+            let newCrowdsaleBalance = new BigNumber(await token.balanceOf(crowdsale.address, {from: owner}));
+            assert.equal(newCrowdsaleBalance.toNumber(), vestedTokens.toNumber());
+
+            // totalSupply stays 10B
+            assert.equal(totalSupply.toNumber(), new BigNumber('10e27').toNumber());
+        });
     });
 });


### PR DESCRIPTION
Optionally burns unsold tokens based on the bool that is passed when calling `finalizeCrowdsale`. `True` will burn the unsold tokens, `false` will send the unsold tokens to the wallet address that collects the crowdsale funds.

Related issue: https://github.com/Stacktical/stacktical-tokensale-contracts/issues/2
> When finalizeCrowdsale is called the unsold token are automatically burned.
Considering the current regulatory climate and the general stance on token burn practices, we would rather have this optional.
We rather have this optional and will make sure to properly communicate on any potential token burn in the near future.